### PR TITLE
Remove unused code

### DIFF
--- a/src/me/raynes/conch.clj
+++ b/src/me/raynes/conch.clj
@@ -228,12 +228,6 @@
               :else result)))))
 
 (defn execute [name & args]
-  (let [[[options] args] ((juxt filter remove) map? args)]
-    (if (:background options)
-      (future (run-command name args options))
-      (run-command name args options))))
-
-(defn execute [name & args]
   (let [end (last args)
         in-arg (first (filter #(seq? %) args))
         args (remove #(seq? %) args)


### PR DESCRIPTION
## Summary
The execute function was defined twice with the same signature and the second binding was overriding the first (unused) one. This commit removes the unused definition of execute.

## Test Plan
Ran the unit tests locally

